### PR TITLE
Enable crawler conditionally

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Update deployment
         run: |
           kubectl set image deployment/registry-api app=${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.sha_short }} --record
+          kubectl set image deployment/registry-crawler app=${{ steps.vars.outputs.docker_image }}:${{ steps.vars.outputs.sha_short }} --record
 
       - name: Verify deployment
-        run: kubectl rollout status deployment/registry-api
+        run: |
+          kubectl rollout status deployment/registry-api
+          kubectl rollout status deployment/registry-crawler

--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ You can configure the application through environment variables:
 - `GRAPHDB_USERNAME`: if using authentication, your GraphDB username (default: empty).
 - `GRAPHDB_PASSWORD`: if using authentication, your GraphDB password (default: empty).
 - `LOG`: enable/disable logging (default: `true`).
+- `CRAWLER_SCHEDULE`: a schedule in Cron format; for example `0 * * * *` to crawl every hour 
+  (default: crawling  disabled). 

--- a/src/server.ts
+++ b/src/server.ts
@@ -119,9 +119,11 @@ server.addContentTypeParser(
 
     // Schedule crawler to check every hour for CRAWLER_INTERVAL that have expired their REGISTRATION_URL_TTL.
     const ttl = ((process.env.REGISTRATION_URL_TTL || 86400) as number) * 1000;
-    scheduleJob(process.env.CRAWLER_INTERVAL || '0 * * * *', () => {
-      crawler.crawl(new Date(Date.now() - ttl));
-    });
+    if (process.env.CRAWLER_SCHEDULE !== undefined) {
+      scheduleJob(process.env.CRAWLER_SCHEDULE, () => {
+        crawler.crawl(new Date(Date.now() - ttl));
+      });
+    }
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
Ref #3.

By default, the crawler was scheduled for every hour.
However, when running multiple replicas of the application,
for instance on a Kubernetes cluster, the crawler ran on
each replica, duplicating effort needlessly.

Therefore, make the crawler dependent on a `CRAWLER_SCHEDULE`
environment variable. This way, we can enable the crawler only
on a separate Kubernetes deployment by setting the variable,
leaving the normal replicas to handle API requests only.