### PR TITLE
Store HTTP status code when crawling

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -19,6 +19,7 @@ export async function fetch(url: URL): Promise<DatasetExt[]> {
   // so first make sure the URL can be retrieved.
   const response = await nodeFetch(url, {
     // Use Comunica’s Accept header.
+    method: 'HEAD',
     headers: {
       Accept:
         'application/n-quads,application/trig;q=0.95,application/ld+json;q=0.9,application/n-triples;q=0.8,text/turtle;q=0.6,application/rdf+xml;q=0.5',
@@ -26,9 +27,9 @@ export async function fetch(url: URL): Promise<DatasetExt[]> {
   });
   if (!response.ok) {
     if (response.status === 404) {
-      throw new UrlNotFound();
+      throw new UrlNotFound(response.status.toString());
     }
-    throw new NoDatasetFoundAtUrl();
+    throw new NoDatasetFoundAtUrl(response.status.toString());
   }
 
   //   return await construct(url);
@@ -56,10 +57,6 @@ const engine = newEngine();
 
 /**
  * Fetch dataset descriptions by executing a SPARQL SELECT query.
- *
- * Use OPTIONALs in order to fetch both complete and incomplete datasets. We want those incomplete datasets in order
- * to have SHACL validation results. Any data not matching this SPARQL query will return nothing, after all, and nothing
- * cannot be validated by SHACL.
  */
 async function query(url: URL): Promise<DatasetExt[]> {
   const {bindingsStream} = (await engine.query(selectQuery, {

--- a/src/graphdb.ts
+++ b/src/graphdb.ts
@@ -187,6 +187,17 @@ export class GraphDbRegistrationStore implements RegistrationStore {
       );
     }
 
+    if (registration.statusCode !== undefined) {
+      quads.push(
+        factory.quad(
+          factory.namedNode(registration.url.toString()),
+          factory.namedNode('http://schema.org/status'),
+          factory.literal(registration.statusCode.toString(), 'xsd:integer'),
+          factory.namedNode(this.registrationsGraph)
+        )
+      );
+    }
+
     await getWriter(quads).end(async (error, result) => {
       await this.client.request('POST', '/statements', result);
     });

--- a/src/registration.ts
+++ b/src/registration.ts
@@ -2,6 +2,7 @@ import {URL} from 'url';
 
 export class Registration {
   private _dateRead?: Date;
+  private _statusCode?: number;
 
   constructor(
     public readonly url: URL,
@@ -12,12 +13,17 @@ export class Registration {
   /**
    * Mark the Registration as read at a date.
    */
-  public read(date: Date = new Date()) {
+  public read(statusCode: number, date: Date = new Date()) {
+    this._statusCode = statusCode;
     this._dateRead = date;
   }
 
   get dateRead() {
     return this._dateRead;
+  }
+
+  get statusCode() {
+    return this._statusCode;
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,7 +75,7 @@ export async function server(
       const registration = new Registration(url, new Date(), [
         ...extractIris(datasets).keys(),
       ]);
-      registration.read();
+      registration.read(200);
       await registrationStore.store(registration);
     }
   });

--- a/test/mock.ts
+++ b/test/mock.ts
@@ -1,0 +1,33 @@
+import {Registration, RegistrationStore} from '../src/registration';
+import {URL} from 'url';
+import {DatasetStore} from '../src/dataset';
+import DatasetExt from 'rdf-ext/lib/Dataset';
+
+export class MockRegistrationStore implements RegistrationStore {
+  private readonly registrations: Map<URL, Registration> = new Map();
+
+  all(): Registration[] {
+    return [...this.registrations.values()];
+  }
+
+  findRegistrationsReadBefore(date: Date): Promise<Registration[]> {
+    return Promise.resolve(
+      [...this.registrations.values()].filter(
+        (registration: Registration) =>
+          registration.dateRead && registration.dateRead < date
+      )
+    );
+  }
+
+  store(registration: Registration): void {
+    this.registrations.set(registration.url, registration);
+  }
+}
+
+export class MockDatasetStore implements DatasetStore {
+  private readonly datasets = [];
+
+  store(datasets: DatasetExt[]): void {
+    datasets.push(...datasets);
+  }
+}

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,28 +1,15 @@
 import nock from 'nock';
 import {FastifyInstance} from 'fastify';
 import {Server} from 'http';
-import DatasetExt from 'rdf-ext/lib/Dataset';
 import {server} from '../src/server';
 import {ShaclValidator} from '../src/validator';
-import {Registration, RegistrationStore} from '../src/registration';
-
-const datasetStore = {
-  store: (datasets: DatasetExt[]) => {},
-};
-
-class MockRegistrationStore implements RegistrationStore {
-  findRegistrationsReadBefore(date: Date): Promise<Registration[]> {
-    return Promise.resolve([]);
-  }
-
-  store(registration: Registration): void {}
-}
+import {MockDatasetStore, MockRegistrationStore} from './mock';
 
 let httpServer: FastifyInstance<Server>;
 describe('Server', () => {
   beforeAll(async () => {
     httpServer = await server(
-      datasetStore,
+      new MockDatasetStore(),
       new MockRegistrationStore(),
       await ShaclValidator.fromUrl('shacl/dataset.jsonld')
     );


### PR DESCRIPTION
Fix #57.

* Extract mock stores for re-use in tests.
* Do first fetch as HEAD request for better performance.