### PR TITLE
Work around filter bug by using isBlank

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -111,7 +111,7 @@ export const selectQuery = `
       OPTIONAL { ${dataset} schema:version ${version} }
       OPTIONAL { ${dataset} schema:mainEntityOfPage ${mainEntityOfPage} }
  
-      FILTER isIri(${license})
+      FILTER (!isBlank(${license}))
 
     ${creator} a schema:Organization ;
       schema:name ${creatorName} .


### PR DESCRIPTION
Fix #72.

isIri doesn't play well with the `@vocab` notation:

```
"@context": {
  "@vocab": "http://schema.org/"
},
```