### PR TITLE
Support Schema.org at both HTTP and HTTPS

### DIFF
--- a/shacl/dataset.jsonld
+++ b/shacl/dataset.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "schema": "http://schema.org/",
+    "schema": "https://schema.org/",
     "dcat": "http://www.w3.org/ns/dcat#",
     "dct": "http://purl.org/dc/terms/",
     "foaf": "http://xmlns.com/foaf/0.1/",

--- a/src/query.ts
+++ b/src/query.ts
@@ -91,6 +91,7 @@ const distributionMapping = new Map([
 export const datasetType = dcat('Dataset');
 export const selectQuery = `
   PREFIX dcat: <http://www.w3.org/ns/dcat#>
+  PREFIX schema: <https://schema.org/>
   PREFIX dct: <http://purl.org/dc/terms/>
   SELECT * WHERE {
     {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -30,6 +30,7 @@ export class ShaclValidator implements Validator {
         quad.predicate.value ===
           'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' &&
         (quad.object.value === 'http://schema.org/Dataset' ||
+          quad.object.value === 'https://schema.org/Dataset' ||
           quad.object.value === 'http://www.w3.org/ns/dcat#Dataset')
     );
     if (datasetIris.size === 0) {

--- a/test/datasets/dataset-http-schema-org-invalid.jsonld
+++ b/test/datasets/dataset-http-schema-org-invalid.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": "http://schema.org/",
+  "@type": "Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "name": "Alba amicorum van de Koninklijke Bibliotheek",
+  "description": "Alba amicorum van de Koninklijke Bibliotheek, een dataset gedefinieerd voor het Europeana Rise of Literacy project.",
+  "url": "https://www.kb.nl/bronnen-zoekwijzers/kb-collecties/moderne-handschriften-vanaf-ca-1550/alba-amicorum",
+  "identifier": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "keywords": [
+    "alba amicorum"
+  ],
+  "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "creator": {
+    "@type": "Organization",
+    "url": "https://www.kb.nl/",
+    "name": "Koninklijke Bibliotheek",
+    "sameAs": "https://ror.org/02w4jbg70"
+  },
+  "distribution": [
+  ]
+}

--- a/test/datasets/dataset-http-schema-org-valid.jsonld
+++ b/test/datasets/dataset-http-schema-org-valid.jsonld
@@ -1,0 +1,25 @@
+{
+  "@context": "http://schema.org/",
+  "@type": "Dataset",
+  "@id": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "name": "Alba amicorum van de Koninklijke Bibliotheek",
+  "url": "https://www.kb.nl/bronnen-zoekwijzers/kb-collecties/moderne-handschriften-vanaf-ca-1550/alba-amicorum",
+  "identifier": "http://data.bibliotheken.nl/id/dataset/rise-alba",
+  "keywords": [
+    "alba amicorum"
+  ],
+  "license": "http://creativecommons.org/publicdomain/zero/1.0/",
+  "creator": {
+    "@type": "Organization",
+    "url": "https://www.kb.nl/",
+    "name": "Koninklijke Bibliotheek",
+    "sameAs": "https://ror.org/02w4jbg70"
+  },
+  "distribution": [
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "application/rdf+xml",
+      "contentUrl": "http://data.bibliotheken.nl/id/dataset/rise-alba.rdf"
+    }
+  ]
+}

--- a/test/http/invalid-dataset.json
+++ b/test/http/invalid-dataset.json
@@ -8,7 +8,7 @@
         "response": "<!DOCTYPE html><html lang=\"nl\"><body><script type=\"application/ld+json\">{ \"@context\":\"https://schema.org/\", \"@type\":\"Dataset\", \"@id\":\"http://data.bibliotheken.nl/id/dataset/rise-alba\", \"name\":\"Alba amicorum van de Koninklijke Bibliotheek\", \"description\":\"Alba amicorum van de Koninklijke Bibliotheek, een dataset gedefinieerd voor het Europeana Rise of Literacy project.\", \"url\":\"https://www.kb.nl/bronnen-zoekwijzers/kb-collecties/moderne-handschriften-vanaf-ca-1550/alba-amicorum\", \"identifier\": \"http://data.bibliotheken.nl/id/dataset/rise-alba\", \"keywords\":[ \"alba amicorum\" ], \"creator\":{ \"@type\":\"Organization\", \"url\": \"https://www.kb.nl/\", \"name\":\"Koninklijke Bibliotheek\", \"sameAs\":\"https://ror.org/02w4jbg70\" }, \"distribution\":[ { \"@type\":\"DataDownload\", \"encodingFormat\":\"application/rdf+xml\", \"contentUrl\":\"http://data.bibliotheken.nl/id/dataset/rise-alba.rdf\" }, { \"@type\":\"DataDownload\", \"encodingFormat\":\"text/turtle\", \"contentUrl\":\"http://data.bibliotheken.nl/id/dataset/rise-alba.ttl\" }, { \"@type\":\"DataDownload\", \"encodingFormat\":\"application/n-triples\", \"contentUrl\":\"http://data.bibliotheken.nl/id/dataset/rise-alba.nt\" }, { \"@type\":\"DataDownload\", \"encodingFormat\":\"application/ld+json\", \"contentUrl\":\"http://data.bibliotheken.nl/id/dataset/rise-alba.json\" } ] }</script></body></html>",
         "rawHeaders": [
             "Date",
-            "Sat, 13 Feb 2021 12:05:27 GMT",
+            "Tue, 09 Mar 2021 12:11:56 GMT",
             "Content-Type",
             "text/html",
             "Content-Length",
@@ -39,11 +39,11 @@
                 "HTML": {
                     "@id": "rdf:HTML"
                 },
-                "@vocab": "http://schema.org/",
+                "@vocab": "https://schema.org/",
                 "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
                 "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
                 "xsd": "http://www.w3.org/2001/XMLSchema#",
-                "schema": "http://schema.org/",
+                "schema": "https://schema.org/",
                 "owl": "http://www.w3.org/2002/07/owl#",
                 "dc": "http://purl.org/dc/elements/1.1/",
                 "dct": "http://purl.org/dc/terms/",
@@ -136,6 +136,9 @@
                 },
                 "AllWheelDriveConfiguration": {
                     "@id": "schema:AllWheelDriveConfiguration"
+                },
+                "AllergiesHealthAspect": {
+                    "@id": "schema:AllergiesHealthAspect"
                 },
                 "AllocateAction": {
                     "@id": "schema:AllocateAction"
@@ -236,9 +239,6 @@
                 "AudiobookFormat": {
                     "@id": "schema:AudiobookFormat"
                 },
-                "AuthenticContent": {
-                    "@id": "schema:AuthenticContent"
-                },
                 "AuthoritativeLegalValue": {
                     "@id": "schema:AuthoritativeLegalValue"
                 },
@@ -271,6 +271,9 @@
                 },
                 "Ayurvedic": {
                     "@id": "schema:Ayurvedic"
+                },
+                "BackOrder": {
+                    "@id": "schema:BackOrder"
                 },
                 "BackgroundNewsArticle": {
                     "@id": "schema:BackgroundNewsArticle"
@@ -343,6 +346,48 @@
                 },
                 "BoatTrip": {
                     "@id": "schema:BoatTrip"
+                },
+                "BodyMeasurementArm": {
+                    "@id": "schema:BodyMeasurementArm"
+                },
+                "BodyMeasurementBust": {
+                    "@id": "schema:BodyMeasurementBust"
+                },
+                "BodyMeasurementChest": {
+                    "@id": "schema:BodyMeasurementChest"
+                },
+                "BodyMeasurementFoot": {
+                    "@id": "schema:BodyMeasurementFoot"
+                },
+                "BodyMeasurementHand": {
+                    "@id": "schema:BodyMeasurementHand"
+                },
+                "BodyMeasurementHead": {
+                    "@id": "schema:BodyMeasurementHead"
+                },
+                "BodyMeasurementHeight": {
+                    "@id": "schema:BodyMeasurementHeight"
+                },
+                "BodyMeasurementHips": {
+                    "@id": "schema:BodyMeasurementHips"
+                },
+                "BodyMeasurementInsideLeg": {
+                    "@id": "schema:BodyMeasurementInsideLeg"
+                },
+                "BodyMeasurementNeck": {
+                    "@id": "schema:BodyMeasurementNeck"
+                },
+                "BodyMeasurementTypeEnumeration": {
+                    "@id": "schema:BodyMeasurementTypeEnumeration"
+                },
+                "BodyMeasurementUnderbust": {
+                    "@id": "schema:BodyMeasurementUnderbust"
+                },
+                "BodyMeasurementWaist": {
+                    "@id": "schema:BodyMeasurementWaist"
+                },
+                "BodyMeasurementWeight": {
+                    "@id": "schema:BodyMeasurementWeight"
                 },
                 "BodyOfWater": {
                     "@id": "schema:BodyOfWater"
@@ -785,6 +830,9 @@
                 "DeactivateAction": {
                     "@id": "schema:DeactivateAction"
                 },
+                "DecontextualizedContent": {
+                    "@id": "schema:DecontextualizedContent"
+                },
                 "DefenceEstablishment": {
                     "@id": "schema:DefenceEstablishment"
                 },
@@ -1010,6 +1058,9 @@
                 "EatAction": {
                     "@id": "schema:EatAction"
                 },
+                "EditedOrCroppedContent": {
+                    "@id": "schema:EditedOrCroppedContent"
+                },
                 "EducationEvent": {
                     "@id": "schema:EducationEvent"
                 },
@@ -1024,6 +1075,9 @@
                 },
                 "EducationalOrganization": {
                     "@id": "schema:EducationalOrganization"
+                },
+                "EffectivenessHealthAspect": {
+                    "@id": "schema:EffectivenessHealthAspect"
                 },
                 "Electrician": {
                     "@id": "schema:Electrician"
@@ -1325,6 +1379,9 @@
                 "Geriatric": {
                     "@id": "schema:Geriatric"
                 },
+                "GettingAccessHealthAspect": {
+                    "@id": "schema:GettingAccessHealthAspect"
+                },
                 "GiveAction": {
                     "@id": "schema:GiveAction"
                 },
@@ -1463,6 +1520,9 @@
                 "HousePainter": {
                     "@id": "schema:HousePainter"
                 },
+                "HowItWorksHealthAspect": {
+                    "@id": "schema:HowItWorksHealthAspect"
+                },
                 "HowOrWhereHealthAspect": {
                     "@id": "schema:HowOrWhereHealthAspect"
                 },
@@ -1534,6 +1594,9 @@
                 },
                 "InformAction": {
                     "@id": "schema:InformAction"
+                },
+                "IngredientsHealthAspect": {
+                    "@id": "schema:IngredientsHealthAspect"
                 },
                 "InsertAction": {
                     "@id": "schema:InsertAction"
@@ -1793,6 +1856,9 @@
                 "MayTreatHealthAspect": {
                     "@id": "schema:MayTreatHealthAspect"
                 },
+                "MeasurementTypeEnumeration": {
+                    "@id": "schema:MeasurementTypeEnumeration"
+                },
                 "MediaGallery": {
                     "@id": "schema:MediaGallery"
                 },
@@ -1987,9 +2053,6 @@
                 },
                 "MisconceptionsHealthAspect": {
                     "@id": "schema:MisconceptionsHealthAspect"
-                },
-                "MissingContext": {
-                    "@id": "schema:MissingContext"
                 },
                 "MixedEventAttendanceMode": {
                     "@id": "schema:MixedEventAttendanceMode"
@@ -2321,6 +2384,9 @@
                 "OccupationalActivity": {
                     "@id": "schema:OccupationalActivity"
                 },
+                "OccupationalExperienceRequirements": {
+                    "@id": "schema:OccupationalExperienceRequirements"
+                },
                 "OccupationalTherapy": {
                     "@id": "schema:OccupationalTherapy"
                 },
@@ -2443,6 +2509,9 @@
                 },
                 "OrganizeAction": {
                     "@id": "schema:OrganizeAction"
+                },
+                "OriginalMediaContent": {
+                    "@id": "schema:OriginalMediaContent"
                 },
                 "OriginalShippingFees": {
                     "@id": "schema:OriginalShippingFees"
@@ -2686,6 +2755,9 @@
                 },
                 "PreSale": {
                     "@id": "schema:PreSale"
+                },
+                "PregnancyHealthAspect": {
+                    "@id": "schema:PregnancyHealthAspect"
                 },
                 "PrependAction": {
                     "@id": "schema:PrependAction"
@@ -3083,11 +3155,17 @@
                 "SRP": {
                     "@id": "schema:SRP"
                 },
+                "SafetyHealthAspect": {
+                    "@id": "schema:SafetyHealthAspect"
+                },
                 "SaleEvent": {
                     "@id": "schema:SaleEvent"
                 },
                 "SalePrice": {
                     "@id": "schema:SalePrice"
+                },
+                "SatireOrParodyContent": {
+                    "@id": "schema:SatireOrParodyContent"
                 },
                 "SatiricalArticle": {
                     "@id": "schema:SatiricalArticle"
@@ -3206,6 +3284,21 @@
                 "SiteNavigationElement": {
                     "@id": "schema:SiteNavigationElement"
                 },
+                "SizeGroupEnumeration": {
+                    "@id": "schema:SizeGroupEnumeration"
+                },
+                "SizeSpecification": {
+                    "@id": "schema:SizeSpecification"
+                },
+                "SizeSystemEnumeration": {
+                    "@id": "schema:SizeSystemEnumeration"
+                },
+                "SizeSystemImperial": {
+                    "@id": "schema:SizeSystemImperial"
+                },
+                "SizeSystemMetric": {
+                    "@id": "schema:SizeSystemMetric"
+                },
                 "SkiResort": {
                     "@id": "schema:SkiResort"
                 },
@@ -3274,6 +3367,9 @@
                 },
                 "StadiumOrArena": {
                     "@id": "schema:StadiumOrArena"
+                },
+                "StagedContent": {
+                    "@id": "schema:StagedContent"
                 },
                 "StagesHealthAspect": {
                     "@id": "schema:StagesHealthAspect"
@@ -3485,6 +3581,9 @@
                 "TransferAction": {
                     "@id": "schema:TransferAction"
                 },
+                "TransformedContent": {
+                    "@id": "schema:TransformedContent"
+                },
                 "TransitMap": {
                     "@id": "schema:TransitMap"
                 },
@@ -3688,6 +3787,144 @@
                 },
                 "WearAction": {
                     "@id": "schema:WearAction"
+                },
+                "WearableMeasurementBack": {
+                    "@id": "schema:WearableMeasurementBack"
+                },
+                "WearableMeasurementChestOrBust": {
+                    "@id": "schema:WearableMeasurementChestOrBust"
+                },
+                "WearableMeasurementCollar": {
+                    "@id": "schema:WearableMeasurementCollar"
+                },
+                "WearableMeasurementCup": {
+                    "@id": "schema:WearableMeasurementCup"
+                },
+                "WearableMeasurementHeight": {
+                    "@id": "schema:WearableMeasurementHeight"
+                },
+                "WearableMeasurementHips": {
+                    "@id": "schema:WearableMeasurementHips"
+                },
+                "WearableMeasurementInseam": {
+                    "@id": "schema:WearableMeasurementInseam"
+                },
+                "WearableMeasurementLength": {
+                    "@id": "schema:WearableMeasurementLength"
+                },
+                "WearableMeasurementOutsideLeg": {
+                    "@id": "schema:WearableMeasurementOutsideLeg"
+                },
+                "WearableMeasurementSleeve": {
+                    "@id": "schema:WearableMeasurementSleeve"
+                },
+                "WearableMeasurementTypeEnumeration": {
+                    "@id": "schema:WearableMeasurementTypeEnumeration"
+                },
+                "WearableMeasurementWaist": {
+                    "@id": "schema:WearableMeasurementWaist"
+                },
+                "WearableMeasurementWidth": {
+                    "@id": "schema:WearableMeasurementWidth"
+                },
+                "WearableSizeGroupBig": {
+                    "@id": "schema:WearableSizeGroupBig"
+                },
+                "WearableSizeGroupBoys": {
+                    "@id": "schema:WearableSizeGroupBoys"
+                },
+                "WearableSizeGroupEnumeration": {
+                    "@id": "schema:WearableSizeGroupEnumeration"
+                },
+                "WearableSizeGroupExtraShort": {
+                    "@id": "schema:WearableSizeGroupExtraShort"
+                },
+                "WearableSizeGroupExtraTall": {
+                    "@id": "schema:WearableSizeGroupExtraTall"
+                },
+                "WearableSizeGroupGirls": {
+                    "@id": "schema:WearableSizeGroupGirls"
+                },
+                "WearableSizeGroupHusky": {
+                    "@id": "schema:WearableSizeGroupHusky"
+                },
+                "WearableSizeGroupInfants": {
+                    "@id": "schema:WearableSizeGroupInfants"
+                },
+                "WearableSizeGroupJuniors": {
+                    "@id": "schema:WearableSizeGroupJuniors"
+                },
+                "WearableSizeGroupMaternity": {
+                    "@id": "schema:WearableSizeGroupMaternity"
+                },
+                "WearableSizeGroupMens": {
+                    "@id": "schema:WearableSizeGroupMens"
+                },
+                "WearableSizeGroupMisses": {
+                    "@id": "schema:WearableSizeGroupMisses"
+                },
+                "WearableSizeGroupPetite": {
+                    "@id": "schema:WearableSizeGroupPetite"
+                },
+                "WearableSizeGroupPlus": {
+                    "@id": "schema:WearableSizeGroupPlus"
+                },
+                "WearableSizeGroupRegular": {
+                    "@id": "schema:WearableSizeGroupRegular"
+                },
+                "WearableSizeGroupShort": {
+                    "@id": "schema:WearableSizeGroupShort"
+                },
+                "WearableSizeGroupTall": {
+                    "@id": "schema:WearableSizeGroupTall"
+                },
+                "WearableSizeGroupWomens": {
+                    "@id": "schema:WearableSizeGroupWomens"
+                },
+                "WearableSizeSystemAU": {
+                    "@id": "schema:WearableSizeSystemAU"
+                },
+                "WearableSizeSystemBR": {
+                    "@id": "schema:WearableSizeSystemBR"
+                },
+                "WearableSizeSystemCN": {
+                    "@id": "schema:WearableSizeSystemCN"
+                },
+                "WearableSizeSystemContinental": {
+                    "@id": "schema:WearableSizeSystemContinental"
+                },
+                "WearableSizeSystemDE": {
+                    "@id": "schema:WearableSizeSystemDE"
+                },
+                "WearableSizeSystemEN13402": {
+                    "@id": "schema:WearableSizeSystemEN13402"
+                },
+                "WearableSizeSystemEnumeration": {
+                    "@id": "schema:WearableSizeSystemEnumeration"
+                },
+                "WearableSizeSystemEurope": {
+                    "@id": "schema:WearableSizeSystemEurope"
+                },
+                "WearableSizeSystemFR": {
+                    "@id": "schema:WearableSizeSystemFR"
+                },
+                "WearableSizeSystemGS1": {
+                    "@id": "schema:WearableSizeSystemGS1"
+                },
+                "WearableSizeSystemIT": {
+                    "@id": "schema:WearableSizeSystemIT"
+                },
+                "WearableSizeSystemJP": {
+                    "@id": "schema:WearableSizeSystemJP"
+                },
+                "WearableSizeSystemMX": {
+                    "@id": "schema:WearableSizeSystemMX"
+                },
+                "WearableSizeSystemUK": {
+                    "@id": "schema:WearableSizeSystemUK"
+                },
+                "WearableSizeSystemUS": {
+                    "@id": "schema:WearableSizeSystemUS"
                 },
                 "WebAPI": {
                     "@id": "schema:WebAPI"
@@ -5217,6 +5454,9 @@
                 "expectsAcceptanceOf": {
                     "@id": "schema:expectsAcceptanceOf"
                 },
+                "experienceInPlaceOfEducation": {
+                    "@id": "schema:experienceInPlaceOfEducation"
+                },
                 "experienceRequirements": {
                     "@id": "schema:experienceRequirements"
                 },
@@ -5498,6 +5738,9 @@
                 "hasMap": {
                     "@id": "schema:hasMap",
                     "@type": "@id"
+                },
+                "hasMeasurement": {
+                    "@id": "schema:hasMeasurement"
                 },
                 "hasMenu": {
                     "@id": "schema:hasMenu"
@@ -6228,6 +6471,9 @@
                 },
                 "monthlyMinimumRepaymentAmount": {
                     "@id": "schema:monthlyMinimumRepaymentAmount"
+                },
+                "monthsOfExperience": {
+                    "@id": "schema:monthsOfExperience"
                 },
                 "mpn": {
                     "@id": "schema:mpn"
@@ -7352,6 +7598,12 @@
                 "size": {
                     "@id": "schema:size"
                 },
+                "sizeGroup": {
+                    "@id": "schema:sizeGroup"
+                },
+                "sizeSystem": {
+                    "@id": "schema:sizeSystem"
+                },
                 "skills": {
                     "@id": "schema:skills"
                 },
@@ -7531,6 +7783,9 @@
                 "sugarContent": {
                     "@id": "schema:sugarContent"
                 },
+                "suggestedAge": {
+                    "@id": "schema:suggestedAge"
+                },
                 "suggestedAnswer": {
                     "@id": "schema:suggestedAnswer"
                 },
@@ -7539,6 +7794,9 @@
                 },
                 "suggestedMaxAge": {
                     "@id": "schema:suggestedMaxAge"
+                },
+                "suggestedMeasurement": {
+                    "@id": "schema:suggestedMeasurement"
                 },
                 "suggestedMinAge": {
                     "@id": "schema:suggestedMinAge"
@@ -8026,21 +8284,21 @@
             "Access-Control-Allow-Origin",
             "*",
             "Date",
-            "Sat, 13 Feb 2021 11:58:40 GMT",
+            "Tue, 09 Mar 2021 12:05:12 GMT",
             "Expires",
-            "Sat, 13 Feb 2021 12:08:40 GMT",
+            "Tue, 09 Mar 2021 12:15:12 GMT",
             "ETag",
-            "\"v7F5aA\"",
+            "\"8OeRUQ\"",
             "X-Cloud-Trace-Context",
-            "8ca75e3cf8705b3b236437131cb30ef5",
+            "77f72fca1f0cc2fbb4193e447f0e8696",
             "Content-Type",
             "application/ld+json",
             "Server",
             "Google Frontend",
             "Content-Length",
-            "156492",
+            "163025",
             "Age",
-            "407",
+            "404",
             "Cache-Control",
             "public, max-age=600",
             "Alt-Svc",

--- a/test/http/post-dataset.json
+++ b/test/http/post-dataset.json
@@ -8,7 +8,7 @@
         "response": "<!DOCTYPE html><html lang=\"nl\"><body><script type=\"application/ld+json\">{ \"@context\":\"https://schema.org/\", \"@type\":\"Dataset\", \"@id\":\"http://data.bibliotheken.nl/id/dataset/rise-alba\", \"name\":\"Alba amicorum van de Koninklijke Bibliotheek\", \"description\":\"Alba amicorum van de Koninklijke Bibliotheek, een dataset gedefinieerd voor het Europeana Rise of Literacy project.\", \"url\":\"https://www.kb.nl/bronnen-zoekwijzers/kb-collecties/moderne-handschriften-vanaf-ca-1550/alba-amicorum\", \"identifier\": \"http://data.bibliotheken.nl/id/dataset/rise-alba\", \"keywords\":[ \"alba amicorum\" ], \"license\" : \"http://creativecommons.org/publicdomain/zero/1.0/\", \"creator\":{ \"@type\":\"Organization\", \"url\": \"https://www.kb.nl/\", \"name\":\"Koninklijke Bibliotheek\", \"sameAs\":\"https://ror.org/02w4jbg70\" }, \"distribution\":[ { \"@type\":\"DataDownload\", \"encodingFormat\":\"application/rdf+xml\", \"contentUrl\":\"http://data.bibliotheken.nl/id/dataset/rise-alba.rdf\" }, { \"@type\":\"DataDownload\", \"encodingFormat\":\"text/turtle\", \"contentUrl\":\"http://data.bibliotheken.nl/id/dataset/rise-alba.ttl\" }, { \"@type\":\"DataDownload\", \"encodingFormat\":\"application/n-triples\", \"contentUrl\":\"http://data.bibliotheken.nl/id/dataset/rise-alba.nt\" }, { \"@type\":\"DataDownload\", \"encodingFormat\":\"application/ld+json\", \"contentUrl\":\"http://data.bibliotheken.nl/id/dataset/rise-alba.json\" } ] }</script></body></html>",
         "rawHeaders": [
             "Date",
-            "Sat, 13 Feb 2021 11:20:08 GMT",
+            "Tue, 09 Mar 2021 12:19:43 GMT",
             "Content-Type",
             "text/html",
             "Content-Length",
@@ -32,55 +32,6 @@
         "path": "/",
         "body": "",
         "status": 200,
-        "response": [
-            "1f8b08000000000002ffac585b6fdb46167e5eff8a095f6c2d44d272dbbdc492b06eddc4596c93609db6088260312447e4d8248799194a169afef7fdce0c49918ad3009bf5834ccee5dc2fdfe1c9f2c9f5ab1fdebc7dfd232b6c55ae4f96f48f95bcce5781a8032c3c0943f65cd442732b32b6d1aa6237aa12d1dd050bc3f509c3dfb2103ceb1eadb4a558dfa685a878a474ce42367a59c67edf5fab84e52c2db836c2ae82d66ec2bf05aca3e3f66a5e8955b09562d7286d0396aada8a1a677732b3c52a135b998ad0bdcc99aca595bc0c4dca4bb15a407627db8850264caa6563a5aa47b446e249c33883304c6d9878002b23935230e3b431cc16dc325173ac19b61349c58d151aeb8a892a11996368ac6e53db6a182be3d04fd5b827a4a60bace139ae6e9466ad112cd98319d76901a2b9acb1c3eb8c291cd78c374d29534eb29a286071a74d29eb7ba645b90a4c0193a4ad6512560998dd373095acc0206eea3c6085169b5510672a35f186c350aa8ef0133c42c9eea15021042cecc958281fa7c64ca97833c0a791dbfadf09c16fb5b2e26bc9345a582b37fbafa5f3a8383e5298d1e92a28ac6dccd338e677fc21ca95ca4bc11b69a254556e2d2e6562e2bb0fadd0fbf89be8bb68d1bd4495aca33b13ac97b1a7d779714cdc7be860db4f8fbbb03a59c63ecb9689caf61d1dcacd1be41ee2c558aead4fcfd78801bfda27a94be25b8b684ad9b54ad98bda089cee0fba443e596672cb64b60a28cb38c251bb141a9689bdd03bcd9b3eb5fa0b14d5b4bb405695dc985550a9a4e6dbee1c0a049decb63c993029557a1f387efdf5b0141b3bdce96e9140462215510a2e469bd8e67d8c07a37ab38cb9378e4bfe188c47afbdc0908df2e133f4eef8967b0f3ddd2a999d",
-            "9dcf2e07c57cb2a93a4572deaf02107ad6d62965e9d90c6e9655ce90ec79811af5ed79c07889874ad46de023c93b9b16c284eb90a885bb02ea4594b30893cf09bf1c6be2ccf9983dc19b7ce48d1b6a928375ae985aba92d9c896838b8d28855306c21d19a745732093f67fcb524e17c60e7145073f2d34b526a29e12ac1178eeddd5b489a6447389249a12fc3287ae2e77f46f7d95febf50e6896a6d47f78a9ebf4895526c6220f687f2076b6aa25fa4da77586ff5653cf6820f09e6727becb8a12d935147f1fff551e302eab1b8498d087d270bd1dbaa69e8408c51fae787b3897a08555dee03d728432d4c5b5af3b34673eb8aa26b8effe9363a774c743a56f1a0ef70ecf03092a22bf9c8b864fd12ad681927eba76caf5ac6b5600438649d53df762e75261eca0d75033403b4f33efed012e3603d5d20d7c27b0c9c44a91a4a04476b0bc0806a410863a0e8e9105a0ad68767a210b93bb7421c0e7bd3146ab7133ba5ef3babdca81d0006a315bae72046a5a04b068c254b43843a4b0c0639611eddddf80e22803d1cbcebdb82d07dff7009da17cf0abde1070fc4865858168bf5afa244431484867c2a9242e85a8bf5c98953c35169a6497e38c91cf84a555922f90036e556cc01f8aaaa05aedb338ebab4a5879db405505a258db323b8a55a009bce071ec48784a426367790aa016a859707204700ec719c3621f2026853d7c2ce09c40df08d9026f01eacca2a610c213acf25117b5567de654ed718ca0e04979fd77cab529eb425d77b96f29a2582d061e635ad78bd6799dc6c8446080128a62a436c9aa9ba120da9a575f6efeb677cce7e92a9560e7e12a2fce7edab97e1bfae23f6a610809d033b09c4992a44e42024890d3600d2a41470a607a0856c0cc4b23b21a07ab7ef2c4b6e0142f50680f0534adcc8724ffa38309d41275b68d5e6e4c09d28cbb0ef11d8e9f0362c5da94c94117b05c1d8e21c9e2e4bca184201862c33e1310a208442c5f57ddb7c02b8c908538f1dbc442aff44461e236e9f08cf1dd4ebac69d40681f01a61054f183cbe0555f17080ec6622172f1195d9dee17cd49163b343d646eda0a0966931ef95a761433c34424bf859b8a425f1287547d1731c49cf540b49321a271e91f82d2f9472527a81a7813332df242ca80c76a5cb53465caa06de1f8a560f8a77bb5db4fb86723d1eb2156897e63f57d086455797908950ec287a5bd3555b509f18d1cf305dc12da50196e8585d616a428530f1eb3601148b1bf70fb3dfc0f778e51ffe264931e141a5025355ce88beb3531fa3135551f173549e3671a87fe033d6f4b9b4376d7228db83e3067e479ebb6206c32fec3b987e0f69ee11e512998ee4417c50a942e9e9474d8ae4de2f7ef2cc442ab3494e205730c53a4b387d720cb40841907e90555b211f6bb10107228d758ca662836718771014a2bfc0640941687ac57fd3488d2b6e02265a1b17731a896f15e8d3c4ea0a339ec64450d3726c0d31c00abe15f44a6da2bb1752c7405c6ca10609ee4d428dc063516a955e9bb1802e230656478665bf0a488e76215c4f07fdc1970e9ae63d2625d3b8c94964e4b72707827f9470bf001f30d56a86212667f8263050ef4295d6232fb3efea470b2e15a8077ddad85173e179e4be07cddd2b830facd27b7791fcd6c388c5223a5f1cfc76649544f743ba03461e2b8efab7838a7f72f0e6994283fc648cf4ab6318e02c340c0c1b770b306a284fc35627a1ac376a80099411bf3891978368b4c6d8c5f9c5225c5c84e7df762e18500aed0ef6f5e0078256bd81ded0b30b73cc52191a17ba1159c9cbe9f1a07f1e4fe08c9d6dfab94dcecd5ccdf3b99ef37935fb4dbe3bf555f4aae6e51e13b37995dc21124fdfaff4a57ca7dfafe8e7e3c7e1feecb74ee433da883eb8fde8c3c78fefdecfa2a635c51992c04f42b3dfe7ee4cb95afcb9460c5d03",
-            "b79ccd2ef90adf121c88f9b1148414cfd4ac2fd315f610a5dd86f97eff86e72f310be3c8bbf3f7973ce2665fa7ab059ee85b457e59450d6a4a6d5fa28b46d20dfadf0b848c3823f53a517f9f9d01e1666a37ef3bf0fcd4dbe7747e0a6c8b9aeebf7384bcb782ffda31bcdd199cccf9e9ecb28738393f3bf55a9cced9e9cf57e177177ff9ebc562f1f770410bbcb58a4e933f19a3c30688937668fe27c83dd03a7c2d1987e6049f4e0313f0dd7d1401daa4af98ff050000ffff03003559a39cd6140000"
-        ],
-        "rawHeaders": [
-            "Access-Control-Allow-Credentials",
-            "true",
-            "Access-Control-Allow-Headers",
-            "Accept",
-            "Access-Control-Allow-Methods",
-            "GET",
-            "Access-Control-Allow-Origin",
-            "*",
-            "Access-Control-Expose-Headers",
-            "Link",
-            "Link",
-            "</docs/jsonldcontext.jsonld>; rel=\"alternate\"; type=\"application/ld+json\"",
-            "Date",
-            "Mon, 22 Feb 2021 12:50:43 GMT",
-            "Expires",
-            "Mon, 22 Feb 2021 13:00:43 GMT",
-            "ETag",
-            "\"v7F5aA\"",
-            "X-Cloud-Trace-Context",
-            "c9f4144fbb2cfea3e4c68844785ec2e0",
-            "Content-Type",
-            "text/html",
-            "Content-Encoding",
-            "gzip",
-            "Server",
-            "Google Frontend",
-            "Content-Length",
-            "2235",
-            "Age",
-            "186",
-            "Cache-Control",
-            "public, max-age=600",
-            "Alt-Svc",
-            "h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
-        ],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://schema.org:443",
-        "method": "GET",
-        "path": "/docs/jsonldcontext.jsonld",
-        "body": "",
-        "status": 200,
         "response": {
             "@context": {
                 "type": "@type",
@@ -88,11 +39,11 @@
                 "HTML": {
                     "@id": "rdf:HTML"
                 },
-                "@vocab": "http://schema.org/",
+                "@vocab": "https://schema.org/",
                 "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
                 "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
                 "xsd": "http://www.w3.org/2001/XMLSchema#",
-                "schema": "http://schema.org/",
+                "schema": "https://schema.org/",
                 "owl": "http://www.w3.org/2002/07/owl#",
                 "dc": "http://purl.org/dc/elements/1.1/",
                 "dct": "http://purl.org/dc/terms/",
@@ -185,6 +136,9 @@
                 },
                 "AllWheelDriveConfiguration": {
                     "@id": "schema:AllWheelDriveConfiguration"
+                },
+                "AllergiesHealthAspect": {
+                    "@id": "schema:AllergiesHealthAspect"
                 },
                 "AllocateAction": {
                     "@id": "schema:AllocateAction"
@@ -285,9 +239,6 @@
                 "AudiobookFormat": {
                     "@id": "schema:AudiobookFormat"
                 },
-                "AuthenticContent": {
-                    "@id": "schema:AuthenticContent"
-                },
                 "AuthoritativeLegalValue": {
                     "@id": "schema:AuthoritativeLegalValue"
                 },
@@ -320,6 +271,9 @@
                 },
                 "Ayurvedic": {
                     "@id": "schema:Ayurvedic"
+                },
+                "BackOrder": {
+                    "@id": "schema:BackOrder"
                 },
                 "BackgroundNewsArticle": {
                     "@id": "schema:BackgroundNewsArticle"
@@ -392,6 +346,48 @@
                 },
                 "BoatTrip": {
                     "@id": "schema:BoatTrip"
+                },
+                "BodyMeasurementArm": {
+                    "@id": "schema:BodyMeasurementArm"
+                },
+                "BodyMeasurementBust": {
+                    "@id": "schema:BodyMeasurementBust"
+                },
+                "BodyMeasurementChest": {
+                    "@id": "schema:BodyMeasurementChest"
+                },
+                "BodyMeasurementFoot": {
+                    "@id": "schema:BodyMeasurementFoot"
+                },
+                "BodyMeasurementHand": {
+                    "@id": "schema:BodyMeasurementHand"
+                },
+                "BodyMeasurementHead": {
+                    "@id": "schema:BodyMeasurementHead"
+                },
+                "BodyMeasurementHeight": {
+                    "@id": "schema:BodyMeasurementHeight"
+                },
+                "BodyMeasurementHips": {
+                    "@id": "schema:BodyMeasurementHips"
+                },
+                "BodyMeasurementInsideLeg": {
+                    "@id": "schema:BodyMeasurementInsideLeg"
+                },
+                "BodyMeasurementNeck": {
+                    "@id": "schema:BodyMeasurementNeck"
+                },
+                "BodyMeasurementTypeEnumeration": {
+                    "@id": "schema:BodyMeasurementTypeEnumeration"
+                },
+                "BodyMeasurementUnderbust": {
+                    "@id": "schema:BodyMeasurementUnderbust"
+                },
+                "BodyMeasurementWaist": {
+                    "@id": "schema:BodyMeasurementWaist"
+                },
+                "BodyMeasurementWeight": {
+                    "@id": "schema:BodyMeasurementWeight"
                 },
                 "BodyOfWater": {
                     "@id": "schema:BodyOfWater"
@@ -834,6 +830,9 @@
                 "DeactivateAction": {
                     "@id": "schema:DeactivateAction"
                 },
+                "DecontextualizedContent": {
+                    "@id": "schema:DecontextualizedContent"
+                },
                 "DefenceEstablishment": {
                     "@id": "schema:DefenceEstablishment"
                 },
@@ -1059,6 +1058,9 @@
                 "EatAction": {
                     "@id": "schema:EatAction"
                 },
+                "EditedOrCroppedContent": {
+                    "@id": "schema:EditedOrCroppedContent"
+                },
                 "EducationEvent": {
                     "@id": "schema:EducationEvent"
                 },
@@ -1073,6 +1075,9 @@
                 },
                 "EducationalOrganization": {
                     "@id": "schema:EducationalOrganization"
+                },
+                "EffectivenessHealthAspect": {
+                    "@id": "schema:EffectivenessHealthAspect"
                 },
                 "Electrician": {
                     "@id": "schema:Electrician"
@@ -1374,6 +1379,9 @@
                 "Geriatric": {
                     "@id": "schema:Geriatric"
                 },
+                "GettingAccessHealthAspect": {
+                    "@id": "schema:GettingAccessHealthAspect"
+                },
                 "GiveAction": {
                     "@id": "schema:GiveAction"
                 },
@@ -1512,6 +1520,9 @@
                 "HousePainter": {
                     "@id": "schema:HousePainter"
                 },
+                "HowItWorksHealthAspect": {
+                    "@id": "schema:HowItWorksHealthAspect"
+                },
                 "HowOrWhereHealthAspect": {
                     "@id": "schema:HowOrWhereHealthAspect"
                 },
@@ -1583,6 +1594,9 @@
                 },
                 "InformAction": {
                     "@id": "schema:InformAction"
+                },
+                "IngredientsHealthAspect": {
+                    "@id": "schema:IngredientsHealthAspect"
                 },
                 "InsertAction": {
                     "@id": "schema:InsertAction"
@@ -1842,6 +1856,9 @@
                 "MayTreatHealthAspect": {
                     "@id": "schema:MayTreatHealthAspect"
                 },
+                "MeasurementTypeEnumeration": {
+                    "@id": "schema:MeasurementTypeEnumeration"
+                },
                 "MediaGallery": {
                     "@id": "schema:MediaGallery"
                 },
@@ -2036,9 +2053,6 @@
                 },
                 "MisconceptionsHealthAspect": {
                     "@id": "schema:MisconceptionsHealthAspect"
-                },
-                "MissingContext": {
-                    "@id": "schema:MissingContext"
                 },
                 "MixedEventAttendanceMode": {
                     "@id": "schema:MixedEventAttendanceMode"
@@ -2370,6 +2384,9 @@
                 "OccupationalActivity": {
                     "@id": "schema:OccupationalActivity"
                 },
+                "OccupationalExperienceRequirements": {
+                    "@id": "schema:OccupationalExperienceRequirements"
+                },
                 "OccupationalTherapy": {
                     "@id": "schema:OccupationalTherapy"
                 },
@@ -2492,6 +2509,9 @@
                 },
                 "OrganizeAction": {
                     "@id": "schema:OrganizeAction"
+                },
+                "OriginalMediaContent": {
+                    "@id": "schema:OriginalMediaContent"
                 },
                 "OriginalShippingFees": {
                     "@id": "schema:OriginalShippingFees"
@@ -2735,6 +2755,9 @@
                 },
                 "PreSale": {
                     "@id": "schema:PreSale"
+                },
+                "PregnancyHealthAspect": {
+                    "@id": "schema:PregnancyHealthAspect"
                 },
                 "PrependAction": {
                     "@id": "schema:PrependAction"
@@ -3132,11 +3155,17 @@
                 "SRP": {
                     "@id": "schema:SRP"
                 },
+                "SafetyHealthAspect": {
+                    "@id": "schema:SafetyHealthAspect"
+                },
                 "SaleEvent": {
                     "@id": "schema:SaleEvent"
                 },
                 "SalePrice": {
                     "@id": "schema:SalePrice"
+                },
+                "SatireOrParodyContent": {
+                    "@id": "schema:SatireOrParodyContent"
                 },
                 "SatiricalArticle": {
                     "@id": "schema:SatiricalArticle"
@@ -3255,6 +3284,21 @@
                 "SiteNavigationElement": {
                     "@id": "schema:SiteNavigationElement"
                 },
+                "SizeGroupEnumeration": {
+                    "@id": "schema:SizeGroupEnumeration"
+                },
+                "SizeSpecification": {
+                    "@id": "schema:SizeSpecification"
+                },
+                "SizeSystemEnumeration": {
+                    "@id": "schema:SizeSystemEnumeration"
+                },
+                "SizeSystemImperial": {
+                    "@id": "schema:SizeSystemImperial"
+                },
+                "SizeSystemMetric": {
+                    "@id": "schema:SizeSystemMetric"
+                },
                 "SkiResort": {
                     "@id": "schema:SkiResort"
                 },
@@ -3323,6 +3367,9 @@
                 },
                 "StadiumOrArena": {
                     "@id": "schema:StadiumOrArena"
+                },
+                "StagedContent": {
+                    "@id": "schema:StagedContent"
                 },
                 "StagesHealthAspect": {
                     "@id": "schema:StagesHealthAspect"
@@ -3534,6 +3581,9 @@
                 "TransferAction": {
                     "@id": "schema:TransferAction"
                 },
+                "TransformedContent": {
+                    "@id": "schema:TransformedContent"
+                },
                 "TransitMap": {
                     "@id": "schema:TransitMap"
                 },
@@ -3737,6 +3787,144 @@
                 },
                 "WearAction": {
                     "@id": "schema:WearAction"
+                },
+                "WearableMeasurementBack": {
+                    "@id": "schema:WearableMeasurementBack"
+                },
+                "WearableMeasurementChestOrBust": {
+                    "@id": "schema:WearableMeasurementChestOrBust"
+                },
+                "WearableMeasurementCollar": {
+                    "@id": "schema:WearableMeasurementCollar"
+                },
+                "WearableMeasurementCup": {
+                    "@id": "schema:WearableMeasurementCup"
+                },
+                "WearableMeasurementHeight": {
+                    "@id": "schema:WearableMeasurementHeight"
+                },
+                "WearableMeasurementHips": {
+                    "@id": "schema:WearableMeasurementHips"
+                },
+                "WearableMeasurementInseam": {
+                    "@id": "schema:WearableMeasurementInseam"
+                },
+                "WearableMeasurementLength": {
+                    "@id": "schema:WearableMeasurementLength"
+                },
+                "WearableMeasurementOutsideLeg": {
+                    "@id": "schema:WearableMeasurementOutsideLeg"
+                },
+                "WearableMeasurementSleeve": {
+                    "@id": "schema:WearableMeasurementSleeve"
+                },
+                "WearableMeasurementTypeEnumeration": {
+                    "@id": "schema:WearableMeasurementTypeEnumeration"
+                },
+                "WearableMeasurementWaist": {
+                    "@id": "schema:WearableMeasurementWaist"
+                },
+                "WearableMeasurementWidth": {
+                    "@id": "schema:WearableMeasurementWidth"
+                },
+                "WearableSizeGroupBig": {
+                    "@id": "schema:WearableSizeGroupBig"
+                },
+                "WearableSizeGroupBoys": {
+                    "@id": "schema:WearableSizeGroupBoys"
+                },
+                "WearableSizeGroupEnumeration": {
+                    "@id": "schema:WearableSizeGroupEnumeration"
+                },
+                "WearableSizeGroupExtraShort": {
+                    "@id": "schema:WearableSizeGroupExtraShort"
+                },
+                "WearableSizeGroupExtraTall": {
+                    "@id": "schema:WearableSizeGroupExtraTall"
+                },
+                "WearableSizeGroupGirls": {
+                    "@id": "schema:WearableSizeGroupGirls"
+                },
+                "WearableSizeGroupHusky": {
+                    "@id": "schema:WearableSizeGroupHusky"
+                },
+                "WearableSizeGroupInfants": {
+                    "@id": "schema:WearableSizeGroupInfants"
+                },
+                "WearableSizeGroupJuniors": {
+                    "@id": "schema:WearableSizeGroupJuniors"
+                },
+                "WearableSizeGroupMaternity": {
+                    "@id": "schema:WearableSizeGroupMaternity"
+                },
+                "WearableSizeGroupMens": {
+                    "@id": "schema:WearableSizeGroupMens"
+                },
+                "WearableSizeGroupMisses": {
+                    "@id": "schema:WearableSizeGroupMisses"
+                },
+                "WearableSizeGroupPetite": {
+                    "@id": "schema:WearableSizeGroupPetite"
+                },
+                "WearableSizeGroupPlus": {
+                    "@id": "schema:WearableSizeGroupPlus"
+                },
+                "WearableSizeGroupRegular": {
+                    "@id": "schema:WearableSizeGroupRegular"
+                },
+                "WearableSizeGroupShort": {
+                    "@id": "schema:WearableSizeGroupShort"
+                },
+                "WearableSizeGroupTall": {
+                    "@id": "schema:WearableSizeGroupTall"
+                },
+                "WearableSizeGroupWomens": {
+                    "@id": "schema:WearableSizeGroupWomens"
+                },
+                "WearableSizeSystemAU": {
+                    "@id": "schema:WearableSizeSystemAU"
+                },
+                "WearableSizeSystemBR": {
+                    "@id": "schema:WearableSizeSystemBR"
+                },
+                "WearableSizeSystemCN": {
+                    "@id": "schema:WearableSizeSystemCN"
+                },
+                "WearableSizeSystemContinental": {
+                    "@id": "schema:WearableSizeSystemContinental"
+                },
+                "WearableSizeSystemDE": {
+                    "@id": "schema:WearableSizeSystemDE"
+                },
+                "WearableSizeSystemEN13402": {
+                    "@id": "schema:WearableSizeSystemEN13402"
+                },
+                "WearableSizeSystemEnumeration": {
+                    "@id": "schema:WearableSizeSystemEnumeration"
+                },
+                "WearableSizeSystemEurope": {
+                    "@id": "schema:WearableSizeSystemEurope"
+                },
+                "WearableSizeSystemFR": {
+                    "@id": "schema:WearableSizeSystemFR"
+                },
+                "WearableSizeSystemGS1": {
+                    "@id": "schema:WearableSizeSystemGS1"
+                },
+                "WearableSizeSystemIT": {
+                    "@id": "schema:WearableSizeSystemIT"
+                },
+                "WearableSizeSystemJP": {
+                    "@id": "schema:WearableSizeSystemJP"
+                },
+                "WearableSizeSystemMX": {
+                    "@id": "schema:WearableSizeSystemMX"
+                },
+                "WearableSizeSystemUK": {
+                    "@id": "schema:WearableSizeSystemUK"
+                },
+                "WearableSizeSystemUS": {
+                    "@id": "schema:WearableSizeSystemUS"
                 },
                 "WebAPI": {
                     "@id": "schema:WebAPI"
@@ -5266,6 +5454,9 @@
                 "expectsAcceptanceOf": {
                     "@id": "schema:expectsAcceptanceOf"
                 },
+                "experienceInPlaceOfEducation": {
+                    "@id": "schema:experienceInPlaceOfEducation"
+                },
                 "experienceRequirements": {
                     "@id": "schema:experienceRequirements"
                 },
@@ -5547,6 +5738,9 @@
                 "hasMap": {
                     "@id": "schema:hasMap",
                     "@type": "@id"
+                },
+                "hasMeasurement": {
+                    "@id": "schema:hasMeasurement"
                 },
                 "hasMenu": {
                     "@id": "schema:hasMenu"
@@ -6277,6 +6471,9 @@
                 },
                 "monthlyMinimumRepaymentAmount": {
                     "@id": "schema:monthlyMinimumRepaymentAmount"
+                },
+                "monthsOfExperience": {
+                    "@id": "schema:monthsOfExperience"
                 },
                 "mpn": {
                     "@id": "schema:mpn"
@@ -7401,6 +7598,12 @@
                 "size": {
                     "@id": "schema:size"
                 },
+                "sizeGroup": {
+                    "@id": "schema:sizeGroup"
+                },
+                "sizeSystem": {
+                    "@id": "schema:sizeSystem"
+                },
                 "skills": {
                     "@id": "schema:skills"
                 },
@@ -7580,6 +7783,9 @@
                 "sugarContent": {
                     "@id": "schema:sugarContent"
                 },
+                "suggestedAge": {
+                    "@id": "schema:suggestedAge"
+                },
                 "suggestedAnswer": {
                     "@id": "schema:suggestedAnswer"
                 },
@@ -7588,6 +7794,9 @@
                 },
                 "suggestedMaxAge": {
                     "@id": "schema:suggestedMaxAge"
+                },
+                "suggestedMeasurement": {
+                    "@id": "schema:suggestedMeasurement"
                 },
                 "suggestedMinAge": {
                     "@id": "schema:suggestedMinAge"
@@ -8075,21 +8284,21 @@
             "Access-Control-Allow-Origin",
             "*",
             "Date",
-            "Mon, 22 Feb 2021 12:49:19 GMT",
+            "Tue, 09 Mar 2021 12:15:45 GMT",
             "Expires",
-            "Mon, 22 Feb 2021 12:59:19 GMT",
+            "Tue, 09 Mar 2021 12:25:45 GMT",
             "ETag",
-            "\"v7F5aA\"",
+            "\"8OeRUQ\"",
             "X-Cloud-Trace-Context",
-            "c9d815319397198ca65070a28066980b",
+            "77f72fca1f0cc2fbb4193e447f0e8696",
             "Content-Type",
             "application/ld+json",
             "Server",
             "Google Frontend",
             "Content-Length",
-            "156492",
+            "163025",
             "Age",
-            "270",
+            "238",
             "Cache-Control",
             "public, max-age=600",
             "Alt-Svc",
@@ -8106,7 +8315,7 @@
         "response": "",
         "rawHeaders": [
             "Date",
-            "Mon, 22 Feb 2021 12:53:49 GMT",
+            "Tue, 09 Mar 2021 12:19:43 GMT",
             "Content-Type",
             "text/html",
             "Content-Length",
@@ -8133,7 +8342,7 @@
         "response": "<!DOCTYPE html><html lang=\"nl\"><body><script type=\"application/ld+json\">{ \"@context\":\"https://schema.org/\", \"@type\":\"Dataset\", \"@id\":\"http://data.bibliotheken.nl/id/dataset/rise-alba\", \"name\":\"Alba amicorum van de Koninklijke Bibliotheek\", \"description\":\"Alba amicorum van de Koninklijke Bibliotheek, een dataset gedefinieerd voor het Europeana Rise of Literacy project.\", \"url\":\"https://www.kb.nl/bronnen-zoekwijzers/kb-collecties/moderne-handschriften-vanaf-ca-1550/alba-amicorum\", \"identifier\": \"http://data.bibliotheken.nl/id/dataset/rise-alba\", \"keywords\":[ \"alba amicorum\" ], \"license\" : \"http://creativecommons.org/publicdomain/zero/1.0/\", \"creator\":{ \"@type\":\"Organization\", \"url\": \"https://www.kb.nl/\", \"name\":\"Koninklijke Bibliotheek\", \"sameAs\":\"https://ror.org/02w4jbg70\" }, \"distribution\":[ { \"@type\":\"DataDownload\", \"encodingFormat\":\"application/rdf+xml\", \"contentUrl\":\"http://data.bibliotheken.nl/id/dataset/rise-alba.rdf\" }, { \"@type\":\"DataDownload\", \"encodingFormat\":\"text/turtle\", \"contentUrl\":\"http://data.bibliotheken.nl/id/dataset/rise-alba.ttl\" }, { \"@type\":\"DataDownload\", \"encodingFormat\":\"application/n-triples\", \"contentUrl\":\"http://data.bibliotheken.nl/id/dataset/rise-alba.nt\" }, { \"@type\":\"DataDownload\", \"encodingFormat\":\"application/ld+json\", \"contentUrl\":\"http://data.bibliotheken.nl/id/dataset/rise-alba.json\" } ] }</script></body></html>",
         "rawHeaders": [
             "Date",
-            "Mon, 22 Feb 2021 12:53:49 GMT",
+            "Tue, 09 Mar 2021 12:19:43 GMT",
             "Content-Type",
             "text/html",
             "Content-Length",
@@ -8157,55 +8366,6 @@
         "path": "/",
         "body": "",
         "status": 200,
-        "response": [
-            "1f8b08000000000002ffac585b6fdb46167e5eff8a095f6c2d44d272dbbdc492b06eddc4596c93609db6088260312447e4d8248799194a169afef7fdce0c49918ad3009bf5834ccee5dc2fdfe1c9f2c9f5ab1fdebc7dfd232b6c55ae4f96f48f95bcce5781a8032c3c0943f65cd442732b32b6d1aa6237aa12d1dd050bc3f509c3dfb2103ceb1eadb4a558dfa685a878a474ce42367a59c67edf5fab84e52c2db836c2ae82d66ec2bf05aca3e3f66a5e8955b09562d7286d0396aada8a1a677732b3c52a135b998ad0bdcc99aca595bc0c4dca4bb15a407627db8850264caa6563a5aa47b446e249c33883304c6d9878002b23935230e3b431cc16dc325173ac19b61349c58d151aeb8a892a11996368ac6e53db6a182be3d04fd5b827a4a60bace139ae6e9466ad112cd98319d76901a2b9acb1c3eb8c291cd78c374d29534eb29a286071a74d29eb7ba645b90a4c0193a4ad6512560998dd373095acc0206eea3c6085169b5510672a35f186c350aa8ef0133c42c9eea15021042cecc958281fa7c64ca97833c0a791dbfadf09c16fb5b2e26bc9345a582b37fbafa5f3a8383e5298d1e92a28ac6dccd338e677fc21ca95ca4bc11b69a254556e2d2e6562e2bb0fadd0fbf89be8bb68d1bd4495aca33b13ac97b1a7d779714cdc7be860db4f8fbbb03a59c63ecb9689caf61d1dcacd1be41ee2c558aead4fcfd78801bfda27a94be25b8b684ad9b54ad98bda089cee0fba443e596672cb64b60a28cb38c251bb141a9689bdd03bcd9b3eb5fa0b14d5b4bb405695dc985550a9a4e6dbee1c0a049decb63c993029557a1f387efdf5b0141b3bdce96e9140462215510a2e469bd8e67d8c07a37ab38cb9378e4bfe188c47afbdc0908df2e133f4eef8967b0f3ddd2a999d",
-            "9dcf2e07c57cb2a93a4572deaf02107ad6d62965e9d90c6e9655ce90ec79811af5ed79c07889874ad46de023c93b9b16c284eb90a885bb02ea4594b30893cf09bf1c6be2ccf9983dc19b7ce48d1b6a928375ae985aba92d9c896838b8d28855306c21d19a745732093f67fcb524e17c60e7145073f2d34b526a29e12ac1178eeddd5b489a6447389249a12fc3287ae2e77f46f7d95febf50e6896a6d47f78a9ebf4895526c6220f687f2076b6aa25fa4da77586ff5653cf6820f09e6727becb8a12d935147f1fff551e302eab1b8498d087d270bd1dbaa69e8408c51fae787b3897a08555dee03d728432d4c5b5af3b34673eb8aa26b8effe9363a774c743a56f1a0ef70ecf03092a22bf9c8b864fd12ad681927eba76caf5ac6b5600438649d53df762e75261eca0d75033403b4f33efed012e3603d5d20d7c27b0c9c44a91a4a04476b0bc0806a410863a0e8e9105a0ad68767a210b93bb7421c0e7bd3146ab7133ba5ef3babdca81d0006a315bae72046a5a04b068c254b43843a4b0c0639611eddddf80e22803d1cbcebdb82d07dff7009da17cf0abde1070fc4865858168bf5afa244431484867c2a9242e85a8bf5c98953c35169a6497e38c91cf84a555922f90036e556cc01f8aaaa05aedb338ebab4a5879db405505a258db323b8a55a009bce071ec48784a426367790aa016a859707204700ec719c3621f2026853d7c2ce09c40df08d9026f01eacca2a610c213acf25117b5567de654ed718ca0e04979fd77cab529eb425d77b96f29a2582d061e635ad78bd6799dc6c8446080128a62a436c9aa9ba120da9a575f6efeb677cce7e92a9560e7e12a2fce7edab97e1bfae23f6a610809d033b09c4992a44e42024890d3600d2a41470a607a0856c0cc4b23b21a07ab7ef2c4b6e0142f50680f0534adcc8724ffa38309d41275b68d5e6e4c09d28cbb0ef11d8e9f0362c5da94c94117b05c1d8e21c9e2e4bca184201862c33e1310a208442c5f57ddb7c02b8c908538f1dbc442aff44461e236e9f08cf1dd4ebac69d40681f01a61054f183cbe0555f17080ec6622172f1195d9dee17cd49163b343d646eda0a0966931ef95a761433c34424bf859b8a425f1287547d1731c49cf540b49321a271e91f82d2f9472527a81a7813332df242ca80c76a5cb53465caa06de1f8a560f8a77bb5db4fb86723d1eb2156897e63f57d086455797908950ec287a5bd3555b509f18d1cf305dc12da50196e8585d616a428530f1eb3601148b1bf70fb3dfc0f778e51ffe264931e141a5025355ce88beb3531fa3135551f173549e3671a87fe033d6f4b9b4376d7228db83e3067e479ebb6206c32fec3b987e0f69ee11e512998ee4417c50a942e9e9474d8ae4de2f7ef2cc442ab3494e205730c53a4b387d720cb40841907e90555b211f6bb10107228d758ca662836718771014a2bfc0640941687ac57fd3488d2b6e02265a1b17731a896f15e8d3c4ea0a339ec64450d3726c0d31c00abe15f44a6da2bb1752c7405c6ca10609ee4d428dc063516a955e9bb1802e230656478665bf0a488e76215c4f07fdc1970e9ae63d2625d3b8c94964e4b72707827f9470bf001f30d56a86212667f8263050ef4295d6232fb3efea470b2e15a8077ddad85173e179e4be07cddd2b830facd27b7791fcd6c388c5223a5f1cfc76649544f743ba03461e2b8efab7838a7f72f0e6994283fc648cf4ab6318e02c340c0c1b770b306a284fc35627a1ac376a80099411bf3891978368b4c6d8c5f9c5225c5c84e7df762e18500aed0ef6f5e0078256bd81ded0b30b73cc52191a17ba1159c9cbe9f1a07f1e4fe08c9d6dfab94dcecd5ccdf3b99ef37935fb4dbe3bf555f4aae6e51e13b37995dc21124fdfaff4a57ca7dfafe8e7e3c7e1feecb74ee433da883eb8fde8c3c78fefdecfa2a635c51992c04f42b3dfe7ee4cb95afcb9460c5d03",
-            "b79ccd2ef90adf121c88f9b1148414cfd4ac2fd315f610a5dd86f97eff86e72f310be3c8bbf3f7973ce2665fa7ab059ee85b457e59450d6a4a6d5fa28b46d20dfadf0b848c3823f53a517f9f9d01e1666a37ef3bf0fcd4dbe7747e0a6c8b9aeebf7384bcb782ffda31bcdd199cccf9e9ecb28738393f3bf55a9cced9e9cf57e177177ff9ebc562f1f770410bbcb58a4e933f19a3c30688937668fe27c83dd03a7c2d1987e6049f4e0313f0dd7d1401daa4af98ff050000ffff03003559a39cd6140000"
-        ],
-        "rawHeaders": [
-            "Access-Control-Allow-Credentials",
-            "true",
-            "Access-Control-Allow-Headers",
-            "Accept",
-            "Access-Control-Allow-Methods",
-            "GET",
-            "Access-Control-Allow-Origin",
-            "*",
-            "Access-Control-Expose-Headers",
-            "Link",
-            "Link",
-            "</docs/jsonldcontext.jsonld>; rel=\"alternate\"; type=\"application/ld+json\"",
-            "Date",
-            "Mon, 22 Feb 2021 12:50:43 GMT",
-            "Expires",
-            "Mon, 22 Feb 2021 13:00:43 GMT",
-            "ETag",
-            "\"v7F5aA\"",
-            "X-Cloud-Trace-Context",
-            "c9f4144fbb2cfea3e4c68844785ec2e0",
-            "Content-Type",
-            "text/html",
-            "Content-Encoding",
-            "gzip",
-            "Server",
-            "Google Frontend",
-            "Content-Length",
-            "2235",
-            "Age",
-            "186",
-            "Cache-Control",
-            "public, max-age=600",
-            "Alt-Svc",
-            "h3-29=\":443\"; ma=2592000,h3-T051=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""
-        ],
-        "responseIsBinary": false
-    },
-    {
-        "scope": "https://schema.org:443",
-        "method": "GET",
-        "path": "/docs/jsonldcontext.jsonld",
-        "body": "",
-        "status": 200,
         "response": {
             "@context": {
                 "type": "@type",
@@ -8213,11 +8373,11 @@
                 "HTML": {
                     "@id": "rdf:HTML"
                 },
-                "@vocab": "http://schema.org/",
+                "@vocab": "https://schema.org/",
                 "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
                 "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
                 "xsd": "http://www.w3.org/2001/XMLSchema#",
-                "schema": "http://schema.org/",
+                "schema": "https://schema.org/",
                 "owl": "http://www.w3.org/2002/07/owl#",
                 "dc": "http://purl.org/dc/elements/1.1/",
                 "dct": "http://purl.org/dc/terms/",
@@ -8310,6 +8470,9 @@
                 },
                 "AllWheelDriveConfiguration": {
                     "@id": "schema:AllWheelDriveConfiguration"
+                },
+                "AllergiesHealthAspect": {
+                    "@id": "schema:AllergiesHealthAspect"
                 },
                 "AllocateAction": {
                     "@id": "schema:AllocateAction"
@@ -8410,9 +8573,6 @@
                 "AudiobookFormat": {
                     "@id": "schema:AudiobookFormat"
                 },
-                "AuthenticContent": {
-                    "@id": "schema:AuthenticContent"
-                },
                 "AuthoritativeLegalValue": {
                     "@id": "schema:AuthoritativeLegalValue"
                 },
@@ -8445,6 +8605,9 @@
                 },
                 "Ayurvedic": {
                     "@id": "schema:Ayurvedic"
+                },
+                "BackOrder": {
+                    "@id": "schema:BackOrder"
                 },
                 "BackgroundNewsArticle": {
                     "@id": "schema:BackgroundNewsArticle"
@@ -8517,6 +8680,48 @@
                 },
                 "BoatTrip": {
                     "@id": "schema:BoatTrip"
+                },
+                "BodyMeasurementArm": {
+                    "@id": "schema:BodyMeasurementArm"
+                },
+                "BodyMeasurementBust": {
+                    "@id": "schema:BodyMeasurementBust"
+                },
+                "BodyMeasurementChest": {
+                    "@id": "schema:BodyMeasurementChest"
+                },
+                "BodyMeasurementFoot": {
+                    "@id": "schema:BodyMeasurementFoot"
+                },
+                "BodyMeasurementHand": {
+                    "@id": "schema:BodyMeasurementHand"
+                },
+                "BodyMeasurementHead": {
+                    "@id": "schema:BodyMeasurementHead"
+                },
+                "BodyMeasurementHeight": {
+                    "@id": "schema:BodyMeasurementHeight"
+                },
+                "BodyMeasurementHips": {
+                    "@id": "schema:BodyMeasurementHips"
+                },
+                "BodyMeasurementInsideLeg": {
+                    "@id": "schema:BodyMeasurementInsideLeg"
+                },
+                "BodyMeasurementNeck": {
+                    "@id": "schema:BodyMeasurementNeck"
+                },
+                "BodyMeasurementTypeEnumeration": {
+                    "@id": "schema:BodyMeasurementTypeEnumeration"
+                },
+                "BodyMeasurementUnderbust": {
+                    "@id": "schema:BodyMeasurementUnderbust"
+                },
+                "BodyMeasurementWaist": {
+                    "@id": "schema:BodyMeasurementWaist"
+                },
+                "BodyMeasurementWeight": {
+                    "@id": "schema:BodyMeasurementWeight"
                 },
                 "BodyOfWater": {
                     "@id": "schema:BodyOfWater"
@@ -8959,6 +9164,9 @@
                 "DeactivateAction": {
                     "@id": "schema:DeactivateAction"
                 },
+                "DecontextualizedContent": {
+                    "@id": "schema:DecontextualizedContent"
+                },
                 "DefenceEstablishment": {
                     "@id": "schema:DefenceEstablishment"
                 },
@@ -9184,6 +9392,9 @@
                 "EatAction": {
                     "@id": "schema:EatAction"
                 },
+                "EditedOrCroppedContent": {
+                    "@id": "schema:EditedOrCroppedContent"
+                },
                 "EducationEvent": {
                     "@id": "schema:EducationEvent"
                 },
@@ -9198,6 +9409,9 @@
                 },
                 "EducationalOrganization": {
                     "@id": "schema:EducationalOrganization"
+                },
+                "EffectivenessHealthAspect": {
+                    "@id": "schema:EffectivenessHealthAspect"
                 },
                 "Electrician": {
                     "@id": "schema:Electrician"
@@ -9499,6 +9713,9 @@
                 "Geriatric": {
                     "@id": "schema:Geriatric"
                 },
+                "GettingAccessHealthAspect": {
+                    "@id": "schema:GettingAccessHealthAspect"
+                },
                 "GiveAction": {
                     "@id": "schema:GiveAction"
                 },
@@ -9637,6 +9854,9 @@
                 "HousePainter": {
                     "@id": "schema:HousePainter"
                 },
+                "HowItWorksHealthAspect": {
+                    "@id": "schema:HowItWorksHealthAspect"
+                },
                 "HowOrWhereHealthAspect": {
                     "@id": "schema:HowOrWhereHealthAspect"
                 },
@@ -9708,6 +9928,9 @@
                 },
                 "InformAction": {
                     "@id": "schema:InformAction"
+                },
+                "IngredientsHealthAspect": {
+                    "@id": "schema:IngredientsHealthAspect"
                 },
                 "InsertAction": {
                     "@id": "schema:InsertAction"
@@ -9967,6 +10190,9 @@
                 "MayTreatHealthAspect": {
                     "@id": "schema:MayTreatHealthAspect"
                 },
+                "MeasurementTypeEnumeration": {
+                    "@id": "schema:MeasurementTypeEnumeration"
+                },
                 "MediaGallery": {
                     "@id": "schema:MediaGallery"
                 },
@@ -10161,9 +10387,6 @@
                 },
                 "MisconceptionsHealthAspect": {
                     "@id": "schema:MisconceptionsHealthAspect"
-                },
-                "MissingContext": {
-                    "@id": "schema:MissingContext"
                 },
                 "MixedEventAttendanceMode": {
                     "@id": "schema:MixedEventAttendanceMode"
@@ -10495,6 +10718,9 @@
                 "OccupationalActivity": {
                     "@id": "schema:OccupationalActivity"
                 },
+                "OccupationalExperienceRequirements": {
+                    "@id": "schema:OccupationalExperienceRequirements"
+                },
                 "OccupationalTherapy": {
                     "@id": "schema:OccupationalTherapy"
                 },
@@ -10617,6 +10843,9 @@
                 },
                 "OrganizeAction": {
                     "@id": "schema:OrganizeAction"
+                },
+                "OriginalMediaContent": {
+                    "@id": "schema:OriginalMediaContent"
                 },
                 "OriginalShippingFees": {
                     "@id": "schema:OriginalShippingFees"
@@ -10860,6 +11089,9 @@
                 },
                 "PreSale": {
                     "@id": "schema:PreSale"
+                },
+                "PregnancyHealthAspect": {
+                    "@id": "schema:PregnancyHealthAspect"
                 },
                 "PrependAction": {
                     "@id": "schema:PrependAction"
@@ -11257,11 +11489,17 @@
                 "SRP": {
                     "@id": "schema:SRP"
                 },
+                "SafetyHealthAspect": {
+                    "@id": "schema:SafetyHealthAspect"
+                },
                 "SaleEvent": {
                     "@id": "schema:SaleEvent"
                 },
                 "SalePrice": {
                     "@id": "schema:SalePrice"
+                },
+                "SatireOrParodyContent": {
+                    "@id": "schema:SatireOrParodyContent"
                 },
                 "SatiricalArticle": {
                     "@id": "schema:SatiricalArticle"
@@ -11380,6 +11618,21 @@
                 "SiteNavigationElement": {
                     "@id": "schema:SiteNavigationElement"
                 },
+                "SizeGroupEnumeration": {
+                    "@id": "schema:SizeGroupEnumeration"
+                },
+                "SizeSpecification": {
+                    "@id": "schema:SizeSpecification"
+                },
+                "SizeSystemEnumeration": {
+                    "@id": "schema:SizeSystemEnumeration"
+                },
+                "SizeSystemImperial": {
+                    "@id": "schema:SizeSystemImperial"
+                },
+                "SizeSystemMetric": {
+                    "@id": "schema:SizeSystemMetric"
+                },
                 "SkiResort": {
                     "@id": "schema:SkiResort"
                 },
@@ -11448,6 +11701,9 @@
                 },
                 "StadiumOrArena": {
                     "@id": "schema:StadiumOrArena"
+                },
+                "StagedContent": {
+                    "@id": "schema:StagedContent"
                 },
                 "StagesHealthAspect": {
                     "@id": "schema:StagesHealthAspect"
@@ -11659,6 +11915,9 @@
                 "TransferAction": {
                     "@id": "schema:TransferAction"
                 },
+                "TransformedContent": {
+                    "@id": "schema:TransformedContent"
+                },
                 "TransitMap": {
                     "@id": "schema:TransitMap"
                 },
@@ -11862,6 +12121,144 @@
                 },
                 "WearAction": {
                     "@id": "schema:WearAction"
+                },
+                "WearableMeasurementBack": {
+                    "@id": "schema:WearableMeasurementBack"
+                },
+                "WearableMeasurementChestOrBust": {
+                    "@id": "schema:WearableMeasurementChestOrBust"
+                },
+                "WearableMeasurementCollar": {
+                    "@id": "schema:WearableMeasurementCollar"
+                },
+                "WearableMeasurementCup": {
+                    "@id": "schema:WearableMeasurementCup"
+                },
+                "WearableMeasurementHeight": {
+                    "@id": "schema:WearableMeasurementHeight"
+                },
+                "WearableMeasurementHips": {
+                    "@id": "schema:WearableMeasurementHips"
+                },
+                "WearableMeasurementInseam": {
+                    "@id": "schema:WearableMeasurementInseam"
+                },
+                "WearableMeasurementLength": {
+                    "@id": "schema:WearableMeasurementLength"
+                },
+                "WearableMeasurementOutsideLeg": {
+                    "@id": "schema:WearableMeasurementOutsideLeg"
+                },
+                "WearableMeasurementSleeve": {
+                    "@id": "schema:WearableMeasurementSleeve"
+                },
+                "WearableMeasurementTypeEnumeration": {
+                    "@id": "schema:WearableMeasurementTypeEnumeration"
+                },
+                "WearableMeasurementWaist": {
+                    "@id": "schema:WearableMeasurementWaist"
+                },
+                "WearableMeasurementWidth": {
+                    "@id": "schema:WearableMeasurementWidth"
+                },
+                "WearableSizeGroupBig": {
+                    "@id": "schema:WearableSizeGroupBig"
+                },
+                "WearableSizeGroupBoys": {
+                    "@id": "schema:WearableSizeGroupBoys"
+                },
+                "WearableSizeGroupEnumeration": {
+                    "@id": "schema:WearableSizeGroupEnumeration"
+                },
+                "WearableSizeGroupExtraShort": {
+                    "@id": "schema:WearableSizeGroupExtraShort"
+                },
+                "WearableSizeGroupExtraTall": {
+                    "@id": "schema:WearableSizeGroupExtraTall"
+                },
+                "WearableSizeGroupGirls": {
+                    "@id": "schema:WearableSizeGroupGirls"
+                },
+                "WearableSizeGroupHusky": {
+                    "@id": "schema:WearableSizeGroupHusky"
+                },
+                "WearableSizeGroupInfants": {
+                    "@id": "schema:WearableSizeGroupInfants"
+                },
+                "WearableSizeGroupJuniors": {
+                    "@id": "schema:WearableSizeGroupJuniors"
+                },
+                "WearableSizeGroupMaternity": {
+                    "@id": "schema:WearableSizeGroupMaternity"
+                },
+                "WearableSizeGroupMens": {
+                    "@id": "schema:WearableSizeGroupMens"
+                },
+                "WearableSizeGroupMisses": {
+                    "@id": "schema:WearableSizeGroupMisses"
+                },
+                "WearableSizeGroupPetite": {
+                    "@id": "schema:WearableSizeGroupPetite"
+                },
+                "WearableSizeGroupPlus": {
+                    "@id": "schema:WearableSizeGroupPlus"
+                },
+                "WearableSizeGroupRegular": {
+                    "@id": "schema:WearableSizeGroupRegular"
+                },
+                "WearableSizeGroupShort": {
+                    "@id": "schema:WearableSizeGroupShort"
+                },
+                "WearableSizeGroupTall": {
+                    "@id": "schema:WearableSizeGroupTall"
+                },
+                "WearableSizeGroupWomens": {
+                    "@id": "schema:WearableSizeGroupWomens"
+                },
+                "WearableSizeSystemAU": {
+                    "@id": "schema:WearableSizeSystemAU"
+                },
+                "WearableSizeSystemBR": {
+                    "@id": "schema:WearableSizeSystemBR"
+                },
+                "WearableSizeSystemCN": {
+                    "@id": "schema:WearableSizeSystemCN"
+                },
+                "WearableSizeSystemContinental": {
+                    "@id": "schema:WearableSizeSystemContinental"
+                },
+                "WearableSizeSystemDE": {
+                    "@id": "schema:WearableSizeSystemDE"
+                },
+                "WearableSizeSystemEN13402": {
+                    "@id": "schema:WearableSizeSystemEN13402"
+                },
+                "WearableSizeSystemEnumeration": {
+                    "@id": "schema:WearableSizeSystemEnumeration"
+                },
+                "WearableSizeSystemEurope": {
+                    "@id": "schema:WearableSizeSystemEurope"
+                },
+                "WearableSizeSystemFR": {
+                    "@id": "schema:WearableSizeSystemFR"
+                },
+                "WearableSizeSystemGS1": {
+                    "@id": "schema:WearableSizeSystemGS1"
+                },
+                "WearableSizeSystemIT": {
+                    "@id": "schema:WearableSizeSystemIT"
+                },
+                "WearableSizeSystemJP": {
+                    "@id": "schema:WearableSizeSystemJP"
+                },
+                "WearableSizeSystemMX": {
+                    "@id": "schema:WearableSizeSystemMX"
+                },
+                "WearableSizeSystemUK": {
+                    "@id": "schema:WearableSizeSystemUK"
+                },
+                "WearableSizeSystemUS": {
+                    "@id": "schema:WearableSizeSystemUS"
                 },
                 "WebAPI": {
                     "@id": "schema:WebAPI"
@@ -13391,6 +13788,9 @@
                 "expectsAcceptanceOf": {
                     "@id": "schema:expectsAcceptanceOf"
                 },
+                "experienceInPlaceOfEducation": {
+                    "@id": "schema:experienceInPlaceOfEducation"
+                },
                 "experienceRequirements": {
                     "@id": "schema:experienceRequirements"
                 },
@@ -13672,6 +14072,9 @@
                 "hasMap": {
                     "@id": "schema:hasMap",
                     "@type": "@id"
+                },
+                "hasMeasurement": {
+                    "@id": "schema:hasMeasurement"
                 },
                 "hasMenu": {
                     "@id": "schema:hasMenu"
@@ -14402,6 +14805,9 @@
                 },
                 "monthlyMinimumRepaymentAmount": {
                     "@id": "schema:monthlyMinimumRepaymentAmount"
+                },
+                "monthsOfExperience": {
+                    "@id": "schema:monthsOfExperience"
                 },
                 "mpn": {
                     "@id": "schema:mpn"
@@ -15526,6 +15932,12 @@
                 "size": {
                     "@id": "schema:size"
                 },
+                "sizeGroup": {
+                    "@id": "schema:sizeGroup"
+                },
+                "sizeSystem": {
+                    "@id": "schema:sizeSystem"
+                },
                 "skills": {
                     "@id": "schema:skills"
                 },
@@ -15705,6 +16117,9 @@
                 "sugarContent": {
                     "@id": "schema:sugarContent"
                 },
+                "suggestedAge": {
+                    "@id": "schema:suggestedAge"
+                },
                 "suggestedAnswer": {
                     "@id": "schema:suggestedAnswer"
                 },
@@ -15713,6 +16128,9 @@
                 },
                 "suggestedMaxAge": {
                     "@id": "schema:suggestedMaxAge"
+                },
+                "suggestedMeasurement": {
+                    "@id": "schema:suggestedMeasurement"
                 },
                 "suggestedMinAge": {
                     "@id": "schema:suggestedMinAge"
@@ -16200,21 +16618,21 @@
             "Access-Control-Allow-Origin",
             "*",
             "Date",
-            "Mon, 22 Feb 2021 12:49:19 GMT",
+            "Tue, 09 Mar 2021 12:15:45 GMT",
             "Expires",
-            "Mon, 22 Feb 2021 12:59:19 GMT",
+            "Tue, 09 Mar 2021 12:25:45 GMT",
             "ETag",
-            "\"v7F5aA\"",
+            "\"8OeRUQ\"",
             "X-Cloud-Trace-Context",
-            "c9d815319397198ca65070a28066980b",
+            "77f72fca1f0cc2fbb4193e447f0e8696",
             "Content-Type",
             "application/ld+json",
             "Server",
             "Google Frontend",
             "Content-Length",
-            "156492",
+            "163025",
             "Age",
-            "270",
+            "239",
             "Cache-Control",
             "public, max-age=600",
             "Alt-Svc",

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -20,6 +20,16 @@ describe('Validator', () => {
     expect(report.state).toBe('invalid');
   });
 
+  it('accepts valid HTTP Schema.org dataset', async () => {
+    const report = await validate('dataset-http-schema-org-valid.jsonld');
+    expect(report.state).toEqual('valid');
+  });
+
+  it('reports invalid HTTP Schema.org dataset', async () => {
+    const report = await validate('dataset-http-schema-org-invalid.jsonld');
+    expect(report.state).toBe('invalid');
+  });
+
   it('accepts valid DCAT dataset', async () => {
     const report = await validate('dataset-dcat-valid.jsonld');
     expect(report.state).toEqual('valid');


### PR DESCRIPTION
Fix #91.

For unknown reasons, our tests started failing on `https://schema.org`; we were querying `http://schema.org` but that wasn’t a problem before.