### PR TITLE
relaxation of dates

### DIFF
--- a/shacl/register.ttl
+++ b/shacl/register.ttl
@@ -88,7 +88,7 @@ reg:CreatorShape
         # reg:SchemaSameAsProperty
 .
 
-reg:DateTimeNodeShape
+reg:DateTimeShape
     a sh:NodeShape ;
     sh:or (
 	   	  [ sh:datatype schema:Date ]
@@ -187,7 +187,7 @@ reg:SchemaDateCreatedProperty a sh:PropertyShape ;
     sh:path schema:dateCreated ;
     sh:minCount 0 ;
     sh:maxCount 1 ;
-    sh:node reg:DateTimeNodeShape ;
+    sh:node reg:DateTimeShape ;
     sh:name "Aanmaakdatum van de datasetbeschrijving"@nl, "Creation date of the dataset description"@en ;
 .
 
@@ -195,7 +195,7 @@ reg:SchemaDatePublishedProperty a sh:PropertyShape ;
     sh:path schema:datePublished ;
     sh:minCount 0 ;
     sh:maxCount 1 ;
-    sh:node reg:DateTimeNodeShape ;
+    sh:node reg:DateTimeShape ;
     sh:name "Publicatiedatum van de datasetbeschrijving"@nl, "Publication date of the dataset description"@en ;
 .
 
@@ -203,7 +203,7 @@ reg:SchemaDateModifiedProperty a sh:PropertyShape ;
     sh:path schema:dataModified ;
     sh:minCount 0 ;
     sh:maxCount 1 ;
-    sh:node reg:DateTimeNodeShape ;
+    sh:node reg:DateTimeShape ;
     sh:name "Datum waarop de datasetbeschrijving voor het laatst is gewijzigd"@nl, "Date on which the dataset description was last modified"@en ;
 .
 

--- a/shacl/register.ttl
+++ b/shacl/register.ttl
@@ -88,6 +88,19 @@ reg:CreatorShape
         # reg:SchemaSameAsProperty
 .
 
+reg:DateTimeNodeShape
+    a sh:NodeShape ;
+    sh:or (
+	   	  [ sh:datatype schema:Date ]
+	   	  [ sh:datatype schema:dateTime ]
+	   	  [ sh:datatype xsd:dateTime ]
+	   	  [ sh:datatype xsd:date ]
+        ) ;
+     sh:name "dateTime" ;
+     sh:message "Datum moet van het type schema:Date/xsd:date of schema:dateTime/xsd:dateTime zijn"@nl, "Date must be schema:Date/xsd:date or schema:dateTime/xsd:dateTime"@en ;
+     sh:severity sh:Warning ;
+.
+
 # TODO 
 # reg:PublisherShape
 
@@ -173,21 +186,24 @@ reg:SchemaDescriptionProperty a sh:PropertyShape ;
 reg:SchemaDateCreatedProperty a sh:PropertyShape ;
     sh:path schema:dateCreated ;
     sh:minCount 0 ;
-    sh:datatype xsd:date ;
+    sh:maxCount 1 ;
+    sh:node reg:DateTimeNodeShape ;
     sh:name "Aanmaakdatum van de datasetbeschrijving"@nl, "Creation date of the dataset description"@en ;
 .
 
 reg:SchemaDatePublishedProperty a sh:PropertyShape ;
     sh:path schema:datePublished ;
     sh:minCount 0 ;
-    sh:datatype xsd:date ;
+    sh:maxCount 1 ;
+    sh:node reg:DateTimeNodeShape ;
     sh:name "Publicatiedatum van de datasetbeschrijving"@nl, "Publication date of the dataset description"@en ;
 .
 
 reg:SchemaDateModifiedProperty a sh:PropertyShape ;
     sh:path schema:dataModified ;
     sh:minCount 0 ;
-    sh:datatype xsd:date ;
+    sh:maxCount 1 ;
+    sh:node reg:DateTimeNodeShape ;
     sh:name "Datum waarop de datasetbeschrijving voor het laatst is gewijzigd"@nl, "Date on which the dataset description was last modified"@en ;
 .
 

--- a/test/datasets/dataset-schema-org-valid.jsonld
+++ b/test/datasets/dataset-schema-org-valid.jsonld
@@ -15,6 +15,9 @@
     "name": "Koninklijke Bibliotheek",
     "sameAs": "https://ror.org/02w4jbg70"
   },
+  "dateModified": "2021-05-27T09:56:21.370767",
+  "datePublished": "2021-05-28",
+  "dateCreated": { "@type": "http://www.w3.org/2001/XMLSchema#date", "@value": "2021-05-27" },
   "distribution": [
     {
       "@type": "DataDownload",

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -47,7 +47,7 @@ describe('Fetch', () => {
     );
 
     expect(datasets).toHaveLength(1);
-    expect(datasets[0].size).toBe(15);
+    expect(datasets[0].size).toBe(18);
   });
 });
 


### PR DESCRIPTION
- relax date properties to include DateTime as schema.org suggests)
- date even relaxter (literal) + testcase
- increased expected size for changed dataset